### PR TITLE
Fix animation of AnimationBuilder

### DIFF
--- a/Chapter11/animation_example/lib/secondPage.dart
+++ b/Chapter11/animation_example/lib/secondPage.dart
@@ -43,7 +43,7 @@ class _SecondPage extends State<SecondPage>
           child: Column(
             children: <Widget>[
               AnimatedBuilder(
-                animation: _rotateAnimation!,
+                animation: _animationController!,
                 builder: (context, widget) {
                   return Transform.translate(
                     offset: _transAnimation!.value,


### PR DESCRIPTION
오류는 안나는데 공홈과 다르고 _rotateAnimation를 중복사용해서 찝찝해유.
<img width="239" alt="스크린샷 2023-11-29 오전 11 41 09" src="https://github.com/rollcake86/DoitFlutter2.0/assets/16129260/2a312b95-5877-4996-9042-42586a97ddf1">

공홈
<img width="381" alt="스크린샷 2023-11-29 오전 11 44 09" src="https://github.com/rollcake86/DoitFlutter2.0/assets/16129260/331e531f-91a2-4141-9985-a297ffedcfd7">

? 대신에 late로 선언해도 되네유